### PR TITLE
feat(movie): 영화 목록 조회 커서 기반 페이지네이션 기능 구현

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,8 @@ model Movie {
   user         User       @relation(fields: [userId], references: [id])
   Review       Review[]
 
+  @@index([id])
+  @@index([createdAt])
   @@index([userId], map: "Movie_user_id_fkey")
   @@fulltext([title])
   @@fulltext([actors])

--- a/src/movies/movies.controller.ts
+++ b/src/movies/movies.controller.ts
@@ -24,6 +24,7 @@ import { GetMoviesResponse } from './interfaces/get-movies-response.interface';
 import { DeleteMovieResponse } from './interfaces/delete-movie-response.interface';
 import { UpdateMovieDto } from './dtos/update-movie.dto';
 import { UpdateMovieResponse } from './interfaces/update-movie-response.interface';
+import { Movie } from './interfaces/movie.interface';
 
 @Controller('movies')
 export class MoviesController {
@@ -72,8 +73,18 @@ export class MoviesController {
   }
 
   @Get()
-  async getMovies(): Promise<GetMoviesResponse> {
-    const data = await this.moviesService.getMovies();
+  async getMovies(
+    @Query('cursor') cursor: number,
+    @Query('page') page: number,
+    @Query('limit') limit: number,
+    @Query('sort') sort: string,
+  ): Promise<GetMoviesResponse> {
+    const data = await this.moviesService.getMovies(
+      +cursor,
+      +page,
+      +limit,
+      sort,
+    );
 
     return {
       status: HttpStatus.OK,

--- a/src/movies/movies.repository.ts
+++ b/src/movies/movies.repository.ts
@@ -48,8 +48,31 @@ export class MoviesRepository {
     return movie;
   }
 
-  async findMovies(): Promise<Movie[]> {
-    const movies = await this.prisma.movie.findMany({});
+  async findMoviesWithOffSet(
+    page: number,
+    limit: number,
+    sort: string,
+  ): Promise<Movie[]> {
+    const movies = await this.prisma.movie.findMany({
+      skip: (page - 1) * 5,
+      take: limit,
+      orderBy: { createdAt: sort == 'asc' ? 'asc' : 'desc' },
+    });
+
+    return movies;
+  }
+
+  async findMoviesWithCursor(
+    cursor: number,
+    limit: number,
+    sort: string,
+  ): Promise<Movie[]> {
+    const movies = await this.prisma.movie.findMany({
+      take: limit,
+      skip: cursor ? 1 : 0,
+      orderBy: { createdAt: sort == 'asc' ? 'asc' : 'desc' },
+      cursor: { id: cursor },
+    });
 
     return movies;
   }

--- a/src/movies/movies.service.ts
+++ b/src/movies/movies.service.ts
@@ -35,8 +35,31 @@ export class MoviesService {
     return movie;
   }
 
-  async getMovies(): Promise<Movie[]> {
-    const movies = await this.moviesRepository.findMovies();
+  async getMovies(
+    cursor: number,
+    page: number,
+    limit: number,
+    sort: string,
+  ): Promise<Movie[]> {
+    if (!sort) {
+      sort = 'desc';
+    }
+    let movies: Movie[];
+    console.log(cursor);
+    console.log(sort);
+    if (cursor) {
+      movies = await this.moviesRepository.findMoviesWithCursor(
+        cursor,
+        limit,
+        sort,
+      );
+    } else if (page) {
+      movies = await this.moviesRepository.findMoviesWithOffSet(
+        page,
+        limit,
+        sort,
+      );
+    }
 
     if (!movies) {
       throw new NotFoundException('존재하지않거나 삭제된 영화입니다.');


### PR DESCRIPTION
## 페이지네이션 종류
- 커서 기반 페이지네이션(`Prisma 내부 기능`): `cursor` 파라미터로 이전 페이지의 마지막 영화 ID를 받아 다음 페이지를 조회하는데, 대량의 데이터가 있을 때 오프셋보다 효율적이기 때문에 다음 페이지, 또는 특정 페이지로 이동에 사용하면 적합
- 오프셋 페이지네이션(`Prisma 내부 기능`): `skip` 파라미터가 있는 경우 기존 오프셋 방식으로 처리하여 특정 페이지 이동 지원하는데, 맨 처음 페이지로 돌아갈 때 사용하면 적합

## 구현 방법
- 커서 기반, 오프셋 페이지네이션 둘 다 혼합하여 사용
- 쿼리 들어온 값에 따라 호출하는 메서드를 분리해서 호출

## 결론
커서 기반 페이지네이션 적용으로 대량 데이터 처리 효율성을 높였으며, `id` 필드 인덱싱을 통해 성능 최적화